### PR TITLE
Make test more realistic (use the fields) and add test using Boost's tokenizer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-all: split1 split2 split6 split7 splitc1 splitc2 splitc3
+all: split1 split2 split6 split7 split8 splitc1 splitc2 splitc3
 
 %: %.cpp
 	g++ -Wall -O3 -std=c++0x -o $@ $<
@@ -7,4 +7,4 @@ all: split1 split2 split6 split7 splitc1 splitc2 splitc3
 .PHONY: clean
 
 clean:
-	@rm -f split1 split2 split6 split7 splitc1 splitc2 splitc3
+	@rm -f split1 split2 split6 split7 split8 splitc1 splitc2 splitc3

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 all: split1 split2 split6 split7 split8 splitc1 splitc2 splitc3
 
 %: %.cpp
-	g++ -Wall -O3 -std=c++0x -o $@ $<
+	g++ -Wall -O3 -o $@ $<
 
 .PHONY: clean
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-all: split1 split2 split6 split7 split8 splitc1 splitc2 splitc3
+all: split1 split2 split6 split7 split8 split9 splitc1 splitc2 splitc3
 
 %: %.cpp
 	g++ -Wall -O3 -o $@ $<
@@ -7,4 +7,4 @@ all: split1 split2 split6 split7 split8 splitc1 splitc2 splitc3
 .PHONY: clean
 
 clean:
-	@rm -f split1 split2 split6 split7 split8 splitc1 splitc2 splitc3
+	@rm -f split1 split2 split6 split7 split8 split9 splitc1 splitc2 splitc3

--- a/split.py
+++ b/split.py
@@ -19,10 +19,10 @@ for line in sys.stdin:
         numChars += len(s)
     count += 1
 
-delta_sec = int(time.time() - start_time)
-print("Python: Saw {0} lines ({1} words/{2} chars) in {3} seconds.".format(count, numWords, numChars, delta_sec), end='')
+delta_sec = float(time.time() - start_time)
+print("Python: Saw {0} lines ({1} words/{2} chars) in {:3.1f} seconds.".format(count, numWords, numChars, delta_sec), end='')
 if delta_sec > 0:
-    lps = int(count/delta_sec)
-    print("  Crunch Speed: {0}".format(lps))
+    lps = count/delta_sec
+    print("  Crunch Speed: {:0.1f}".format(lps))
 else:
     print('')

--- a/split.py
+++ b/split.py
@@ -9,13 +9,18 @@ import sys
 count = 0
 start_time = time.time()
 dummy = None
+numWords = 0
+numChars = 0
 
 for line in sys.stdin:
     dummy = line.split()
+    numWords += len(dummy)
+    for s in dummy:
+        numChars += len(s)
     count += 1
 
 delta_sec = int(time.time() - start_time)
-print("Python: Saw {0} lines in {1} seconds.".format(count, delta_sec), end='')
+print("Python: Saw {0} lines ({1} words/{2} chars) in {3} seconds.".format(count, numWords, numChars, delta_sec), end='')
 if delta_sec > 0:
     lps = int(count/delta_sec)
     print("  Crunch Speed: {0}".format(lps))

--- a/split1.cpp
+++ b/split1.cpp
@@ -33,19 +33,24 @@ int main() {
     time_t start = time(NULL);
 
     cin.sync_with_stdio(false); //disable synchronous IO
+    size_t numWords = 0;
+    size_t numChars = 0;
 
     while(cin) {
         getline(cin, input_line);
         spline.clear(); //empty the vector for the next line to parse
 
         split1(spline, input_line);  
+        numWords += spline.size();
+        for (vector<string>::const_iterator iter = spline.begin(); iter != spline.end(); ++iter)
+            numChars += iter->size();
 
         count++;
     };
 
     count--; //subtract for final over-read
     sec = (int) time(NULL) - start;
-    cerr << "C++   : Saw " << count << " lines in " << sec << " seconds." ;
+    cerr << "C++   : Saw " << count << " lines (" << numWords << " words/" << numChars << " chars) in " << sec << " seconds." ;
     if (sec > 0) {
         lps = count / sec;
         cerr << "  Crunch speed: " << lps << endl;

--- a/split1.cpp
+++ b/split1.cpp
@@ -36,8 +36,7 @@ int main() {
     size_t numWords = 0;
     size_t numChars = 0;
 
-    while(cin) {
-        getline(cin, input_line);
+    while(getline(cin, input_line)) {
         spline.clear(); //empty the vector for the next line to parse
 
         split1(spline, input_line);  
@@ -48,7 +47,6 @@ int main() {
         count++;
     };
 
-    count--; //subtract for final over-read
     sec = (int) time(NULL) - start;
     cerr << "C++   : Saw " << count << " lines (" << numWords << " words/" << numChars << " chars) in " << sec << " seconds." ;
     if (sec > 0) {

--- a/split1.cpp
+++ b/split1.cpp
@@ -1,5 +1,6 @@
 // http://stackoverflow.com/q/9378500/106471
 #include <iostream>                                                              
+#include <iomanip>
 #include <string>
 #include <sstream>
 #include <time.h>
@@ -29,8 +30,8 @@ int main() {
     string input_line;
     vector<string> spline;
     long count = 0;
-    int sec, lps;
-    time_t start = time(NULL);
+    timespec start;
+    clock_gettime(CLOCK_MONOTONIC, &start);
 
     cin.sync_with_stdio(false); //disable synchronous IO
     size_t numWords = 0;
@@ -47,11 +48,13 @@ int main() {
         count++;
     };
 
-    sec = (int) time(NULL) - start;
-    cerr << "C++   : Saw " << count << " lines (" << numWords << " words/" << numChars << " chars) in " << sec << " seconds." ;
+    timespec end;
+    clock_gettime(CLOCK_MONOTONIC, &end);
+    const double sec = (end.tv_sec - start.tv_sec) + (end.tv_nsec - start.tv_nsec) * 1e-9;
+    cerr << "C++   : Saw " << count << " lines (" << numWords << " words/" << numChars << " chars) in " << fixed << setprecision(1) << sec << " seconds." ;
     if (sec > 0) {
-        lps = count / sec;
-        cerr << "  Crunch speed: " << lps << endl;
+        const double lps = count / sec;
+        cerr << "  Crunch speed: " << fixed << setprecision(1) << lps << endl;
     } else
         cerr << endl;
     return 0;

--- a/split2.cpp
+++ b/split2.cpp
@@ -1,5 +1,6 @@
 // http://stackoverflow.com/q/9378500/106471
 #include <iostream>                                                              
+#include <iomanip>
 #include <string>
 #include <sstream>
 #include <time.h>
@@ -19,8 +20,8 @@ int main() {
     string input_line;
     vector<string> spline;
     long count = 0;
-    int sec, lps;
-    time_t start = time(NULL);
+    timespec start;
+    clock_gettime(CLOCK_MONOTONIC, &start);
 
     cin.sync_with_stdio(false); //disable synchronous IO
     size_t numWords = 0;
@@ -37,11 +38,13 @@ int main() {
         count++;
     };
 
-    sec = (int) time(NULL) - start;
-    cerr << "C++   : Saw " << count << " lines (" << numWords << " words/" << numChars << " chars) in " << sec << " seconds." ;
+    timespec end;
+    clock_gettime(CLOCK_MONOTONIC, &end);
+    const double sec = (end.tv_sec - start.tv_sec) + (end.tv_nsec - start.tv_nsec) * 1e-9;
+    cerr << "C++   : Saw " << count << " lines (" << numWords << " words/" << numChars << " chars) in " << fixed << setprecision(1) << sec << " seconds." ;
     if (sec > 0) {
-        lps = count / sec;
-        cerr << "  Crunch speed: " << lps << endl;
+        const double lps = count / sec;
+        cerr << "  Crunch speed: " << fixed << setprecision(1) << lps << endl;
     } else
         cerr << endl;
     return 0;

--- a/split2.cpp
+++ b/split2.cpp
@@ -26,8 +26,7 @@ int main() {
     size_t numWords = 0;
     size_t numChars = 0;
 
-    while(cin) {
-        getline(cin, input_line);
+    while(getline(cin, input_line)) {
         spline.clear(); //empty the vector for the next line to parse
 
         split2(spline, input_line);
@@ -38,7 +37,6 @@ int main() {
         count++;
     };
 
-    count--; //subtract for final over-read
     sec = (int) time(NULL) - start;
     cerr << "C++   : Saw " << count << " lines (" << numWords << " words/" << numChars << " chars) in " << sec << " seconds." ;
     if (sec > 0) {

--- a/split2.cpp
+++ b/split2.cpp
@@ -23,19 +23,24 @@ int main() {
     time_t start = time(NULL);
 
     cin.sync_with_stdio(false); //disable synchronous IO
+    size_t numWords = 0;
+    size_t numChars = 0;
 
     while(cin) {
         getline(cin, input_line);
         spline.clear(); //empty the vector for the next line to parse
 
         split2(spline, input_line);
+        numWords += spline.size();
+        for (vector<string>::const_iterator iter = spline.begin(); iter != spline.end(); ++iter)
+            numChars += iter->size();
 
         count++;
     };
 
     count--; //subtract for final over-read
     sec = (int) time(NULL) - start;
-    cerr << "C++   : Saw " << count << " lines in " << sec << " seconds." ;
+    cerr << "C++   : Saw " << count << " lines (" << numWords << " words/" << numChars << " chars) in " << sec << " seconds." ;
     if (sec > 0) {
         lps = count / sec;
         cerr << "  Crunch speed: " << lps << endl;

--- a/split5.py
+++ b/split5.py
@@ -20,10 +20,10 @@ for line in sys.stdin:
         numChars += len(s)
     count += 1
 
-delta_sec = int(time.time() - start_time)
-print("Python: Saw {0} lines ({1} words/{2} chars) in {3} seconds.".format(count, numWords, numChars, delta_sec), end='')
+delta_sec = float(time.time() - start_time)
+print("Python: Saw {0} lines ({1} words/{2} chars) in {:3.1f} seconds.".format(count, numWords, numChars, delta_sec), end='')
 if delta_sec > 0:
-    lps = int(count/delta_sec)
-    print("  Crunch Speed: {0}".format(lps))
+    lps = count/delta_sec
+    print("  Crunch Speed: {:0.1f}".format(lps))
 else:
     print('')

--- a/split5.py
+++ b/split5.py
@@ -9,14 +9,19 @@ import sys
 count = 0
 start_time = time.time()
 dummy = None
+numWords = 0
+numChars = 0
 
 for line in sys.stdin:
     dummy = []
     dummy = line.split()
+    numWords += len(dummy)
+    for s in dummy:
+        numChars += len(s)
     count += 1
 
 delta_sec = int(time.time() - start_time)
-print("Python: Saw {0} lines in {1} seconds.".format(count, delta_sec), end='')
+print("Python: Saw {0} lines ({1} words/{2} chars) in {3} seconds.".format(count, numWords, numChars, delta_sec), end='')
 if delta_sec > 0:
     lps = int(count/delta_sec)
     print("  Crunch Speed: {0}".format(lps))

--- a/split6.cpp
+++ b/split6.cpp
@@ -24,10 +24,8 @@ public:
     {}
 };
 
-vector<StringRef> split3( string const& str, char delimiter = ' ' )
+void split3( string const& str, vector<StringRef> &result, char delimiter = ' ' )
 {
-    vector<StringRef>   result;
-
     enum State { inSpace, inToken };
 
     State state = inSpace;
@@ -52,12 +50,11 @@ vector<StringRef> split3( string const& str, char delimiter = ' ' )
     {
         result.push_back( StringRef( pTokenBegin, &*str.end() - pTokenBegin ) );
     }
-    return result;
 }
 
 int main() {
     string input_line;
-    vector<string> spline;
+    vector<StringRef> spline;
     long count = 0;
     int sec, lps;
     time_t start = time(NULL);
@@ -67,9 +64,10 @@ int main() {
     size_t numChars = 0;
 
     while(getline(cin, input_line)) {
-        vector<StringRef> const v = split3( input_line );
-        numWords += v.size();
-        for (vector<StringRef>::const_iterator iter = v.begin(); iter != v.end(); ++iter)
+			  spline.clear();
+        split3( input_line, spline );
+        numWords += spline.size();
+        for (vector<StringRef>::const_iterator iter = spline.begin(); iter != spline.end(); ++iter)
             numChars += iter->size();
         count++;
     };

--- a/split6.cpp
+++ b/split6.cpp
@@ -32,7 +32,7 @@ vector<StringRef> split3( string const& str, char delimiter = ' ' )
 
     State state = inSpace;
     char const*     pTokenBegin = 0;    // Init to satisfy compiler.
-    for( auto it = str.begin(); it != str.end(); ++it )
+    for( string::const_iterator it = str.begin(); it != str.end(); ++it )
     {
         State const newState = (*it == delimiter? inSpace : inToken);
         if( newState != state )

--- a/split6.cpp
+++ b/split6.cpp
@@ -63,17 +63,22 @@ int main() {
     time_t start = time(NULL);
 
     cin.sync_with_stdio(false); //disable synchronous IO
+    size_t numWords = 0;
+    size_t numChars = 0;
 
     while(cin) {
         getline(cin, input_line);
 
         vector<StringRef> const v = split3( input_line );
+        numWords += v.size();
+        for (vector<StringRef>::const_iterator iter = v.begin(); iter != v.end(); ++iter)
+            numChars += iter->size();
         count++;
     };
 
     count--; //subtract for final over-read
     sec = (int) time(NULL) - start;
-    cerr << "C++   : Saw " << count << " lines in " << sec << " seconds." ;
+    cerr << "C++   : Saw " << count << " lines (" << numWords << " words/" << numChars << " chars) in " << sec << " seconds." ;
     if (sec > 0) {
         lps = count / sec;
         cerr << "  Crunch speed: " << lps << endl;

--- a/split6.cpp
+++ b/split6.cpp
@@ -66,9 +66,7 @@ int main() {
     size_t numWords = 0;
     size_t numChars = 0;
 
-    while(cin) {
-        getline(cin, input_line);
-
+    while(getline(cin, input_line)) {
         vector<StringRef> const v = split3( input_line );
         numWords += v.size();
         for (vector<StringRef>::const_iterator iter = v.begin(); iter != v.end(); ++iter)
@@ -76,7 +74,6 @@ int main() {
         count++;
     };
 
-    count--; //subtract for final over-read
     sec = (int) time(NULL) - start;
     cerr << "C++   : Saw " << count << " lines (" << numWords << " words/" << numChars << " chars) in " << sec << " seconds." ;
     if (sec > 0) {

--- a/split6.cpp
+++ b/split6.cpp
@@ -1,5 +1,6 @@
 // http://stackoverflow.com/a/9379203/106471
 #include <iostream>                                                              
+#include <iomanip>
 #include <string>
 #include <sstream>
 #include <time.h>
@@ -56,8 +57,8 @@ int main() {
     string input_line;
     vector<StringRef> spline;
     long count = 0;
-    int sec, lps;
-    time_t start = time(NULL);
+    timespec start;
+    clock_gettime(CLOCK_MONOTONIC, &start);
 
     cin.sync_with_stdio(false); //disable synchronous IO
     size_t numWords = 0;
@@ -72,11 +73,13 @@ int main() {
         count++;
     };
 
-    sec = (int) time(NULL) - start;
-    cerr << "C++   : Saw " << count << " lines (" << numWords << " words/" << numChars << " chars) in " << sec << " seconds." ;
+    timespec end;
+    clock_gettime(CLOCK_MONOTONIC, &end);
+    const double sec = (end.tv_sec - start.tv_sec) + (end.tv_nsec - start.tv_nsec) * 1e-9;
+    cerr << "C++   : Saw " << count << " lines (" << numWords << " words/" << numChars << " chars) in " << fixed << setprecision(1) << sec << " seconds." ;
     if (sec > 0) {
-        lps = count / sec;
-        cerr << "  Crunch speed: " << lps << endl;
+        const double lps = count / sec;
+        cerr << "  Crunch speed: " << fixed << setprecision(1) << lps << endl;
     } else
         cerr << endl;
     return 0;

--- a/split6.cpp
+++ b/split6.cpp
@@ -64,7 +64,7 @@ int main() {
     size_t numChars = 0;
 
     while(getline(cin, input_line)) {
-			  spline.clear();
+        spline.clear();
         split3( input_line, spline );
         numWords += spline.size();
         for (vector<StringRef>::const_iterator iter = spline.begin(); iter != spline.end(); ++iter)

--- a/split7.cpp
+++ b/split7.cpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <ctime>
 #include <vector>
+#include <iterator>
 
 #include "strtk.hpp"
 
@@ -23,17 +24,21 @@ int main()
    std::size_t numWords = 0;
    std::size_t numChars = 0;
 
+   spline.reserve(100);
+
    while(std::cin)
    {
+      spline.clear();
+
       std::getline(std::cin, input_line);
-      spline.resize(100);
-      std::size_t numFields = strtk::split(delimiter,
-                   input_line,
-                   spline.begin());
-      spline.resize(numFields);
-      numWords += numFields;
+
+      numWords += strtk::split(delimiter,
+                               input_line,
+                               std::back_inserter(spline));
+
       for (std::vector<StrLimits>::const_iterator iter = spline.begin(); iter != spline.end(); ++iter)
          numChars += iter->second - iter->first;
+
       count++;
    };
 

--- a/split7.cpp
+++ b/split7.cpp
@@ -1,6 +1,7 @@
 // Contributed by Arash Partow (http://www.partow.net/)
 // Requires StrTk (http://www.partow.net/programming/strtk/index.html)
 #include <iostream>
+#include <iomanip>
 #include <string>
 #include <ctime>
 #include <vector>
@@ -15,8 +16,8 @@ int main()
    typedef std::pair<const char *, const char *> StrLimits;
    std::vector<StrLimits> spline;
    long count = 0;
-   int sec, lps;
-   time_t start = time(NULL);
+   timespec start;
+   clock_gettime(CLOCK_MONOTONIC, &start);
 
    std::cin.sync_with_stdio(false); //disable synchronous IO
 
@@ -40,13 +41,15 @@ int main()
       count++;
    };
 
-   sec = (int) time(NULL) - start;
-   std::cerr << "C++   : Saw " << count << " lines (" << numWords << " words/" << numChars << " chars) in " << sec << " seconds." ;
+   timespec end;
+   clock_gettime(CLOCK_MONOTONIC, &end);
+   const double sec = (end.tv_sec - start.tv_sec) + (end.tv_nsec - start.tv_nsec) * 1e-9;
+   std::cerr << "C++   : Saw " << count << " lines (" << numWords << " words/" << numChars << " chars) in " << std::fixed << std::setprecision(1) << sec << " seconds." ;
 
    if (sec > 0)
    {
-      lps = count / sec;
-      std::cerr << "  Crunch speed: " << lps << std::endl;
+      const double lps = count / sec;
+      std::cerr << "  Crunch speed: " << std::fixed << std::setprecision(1) << lps << std::endl;
    }
    else
       std::cerr << std::endl;

--- a/split7.cpp
+++ b/split7.cpp
@@ -26,11 +26,9 @@ int main()
 
    spline.reserve(100);
 
-   while(std::cin)
+   while(std::getline(std::cin, input_line))
    {
       spline.clear();
-
-      std::getline(std::cin, input_line);
 
       numWords += strtk::split(delimiter,
                                input_line,
@@ -42,7 +40,6 @@ int main()
       count++;
    };
 
-   count--; //subtract for final over-read
    sec = (int) time(NULL) - start;
    std::cerr << "C++   : Saw " << count << " lines (" << numWords << " words/" << numChars << " chars) in " << sec << " seconds." ;
 

--- a/split7.cpp
+++ b/split7.cpp
@@ -11,6 +11,8 @@
 int main()
 {
    std::string input_line;
+   typedef std::pair<const char *, const char *> StrLimits;
+   std::vector<StrLimits> spline;
    long count = 0;
    int sec, lps;
    time_t start = time(NULL);
@@ -18,20 +20,26 @@ int main()
    std::cin.sync_with_stdio(false); //disable synchronous IO
 
    const strtk::single_delimiter_predicate<std::string::value_type> delimiter(' ');
-   std::size_t token_count;
+   std::size_t numWords = 0;
+   std::size_t numChars = 0;
 
    while(std::cin)
    {
       std::getline(std::cin, input_line);
-      strtk::split(delimiter,
+      spline.resize(100);
+      std::size_t numFields = strtk::split(delimiter,
                    input_line,
-                   strtk::counting_back_inserter<strtk::std_string::range_t>(token_count));
+                   spline.begin());
+      spline.resize(numFields);
+      numWords += numFields;
+      for (std::vector<StrLimits>::const_iterator iter = spline.begin(); iter != spline.end(); ++iter)
+         numChars += iter->second - iter->first;
       count++;
    };
 
    count--; //subtract for final over-read
    sec = (int) time(NULL) - start;
-   std::cerr << "C++   : Saw " << count << " lines in " << sec << " seconds." ;
+   std::cerr << "C++   : Saw " << count << " lines (" << numWords << " words/" << numChars << " chars) in " << sec << " seconds." ;
 
    if (sec > 0)
    {

--- a/split8.cpp
+++ b/split8.cpp
@@ -20,9 +20,7 @@ int main()
    std::size_t numWords = 0;
    std::size_t numChars = 0;
 
-   while(std::cin)
-   {
-      std::getline(std::cin, input_line);
+   while(std::getline(std::cin, input_line)) {
       Tokenizer fields(input_line, sep);
       numWords += std::distance(fields.begin(), fields.end());
       for (Tokenizer::const_iterator iter = fields.begin(); iter != fields.end(); ++iter)
@@ -30,7 +28,6 @@ int main()
       count++;
    };
 
-   count--; //subtract for final over-read
    sec = (int) time(NULL) - start;
    std::cerr << "C++   : Saw " << count << " lines (" << numWords << " words/" << numChars << " chars) in " << sec << " seconds." ;
 

--- a/split8.cpp
+++ b/split8.cpp
@@ -17,17 +17,22 @@ int main()
 
    typedef boost::tokenizer<boost::char_separator<char> > Tokenizer;
    boost::char_separator<char> sep(" ");
+   std::size_t numWords = 0;
+   std::size_t numChars = 0;
 
    while(std::cin)
    {
       std::getline(std::cin, input_line);
       Tokenizer fields(input_line, sep);
+      numWords += std::distance(fields.begin(), fields.end());
+      for (Tokenizer::const_iterator iter = fields.begin(); iter != fields.end(); ++iter)
+         numChars += iter->size();
       count++;
    };
 
    count--; //subtract for final over-read
    sec = (int) time(NULL) - start;
-   std::cerr << "C++   : Saw " << count << " lines in " << sec << " seconds." ;
+   std::cerr << "C++   : Saw " << count << " lines (" << numWords << " words/" << numChars << " chars) in " << sec << " seconds." ;
 
    if (sec > 0)
    {

--- a/split8.cpp
+++ b/split8.cpp
@@ -15,13 +15,13 @@ int main()
 
    std::cin.sync_with_stdio(false); //disable synchronous IO
 
-	 typedef boost::tokenizer<boost::char_separator<char> > Tokenizer;
-	 boost::char_separator<char> sep(" ");
+   typedef boost::tokenizer<boost::char_separator<char> > Tokenizer;
+   boost::char_separator<char> sep(" ");
 
    while(std::cin)
    {
       std::getline(std::cin, input_line);
-			Tokenizer fields(input_line, sep);
+      Tokenizer fields(input_line, sep);
       count++;
    };
 

--- a/split8.cpp
+++ b/split8.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <iomanip>
 #include <string>
 #include <ctime>
 #include <vector>
@@ -10,8 +11,8 @@ int main()
 {
    std::string input_line;
    long count = 0;
-   int sec, lps;
-   time_t start = time(NULL);
+   timespec start;
+   clock_gettime(CLOCK_MONOTONIC, &start);
 
    std::cin.sync_with_stdio(false); //disable synchronous IO
 
@@ -28,13 +29,15 @@ int main()
       count++;
    };
 
-   sec = (int) time(NULL) - start;
-   std::cerr << "C++   : Saw " << count << " lines (" << numWords << " words/" << numChars << " chars) in " << sec << " seconds." ;
+   timespec end;
+   clock_gettime(CLOCK_MONOTONIC, &end);
+   const double sec = (end.tv_sec - start.tv_sec) + (end.tv_nsec - start.tv_nsec) * 1e-9;
+   std::cerr << "C++   : Saw " << count << " lines (" << numWords << " words/" << numChars << " chars) in " << std::fixed << std::setprecision(1) << sec << " seconds." ;
 
    if (sec > 0)
    {
-      lps = count / sec;
-      std::cerr << "  Crunch speed: " << lps << std::endl;
+      const double lps = count / sec;
+      std::cerr << "  Crunch speed: " << std::fixed << std::setprecision(1) << lps << std::endl;
    }
    else
       std::cerr << std::endl;

--- a/split8.cpp
+++ b/split8.cpp
@@ -1,0 +1,41 @@
+#include <iostream>
+#include <string>
+#include <ctime>
+#include <vector>
+
+#include <boost/tokenizer.hpp>
+
+
+int main()
+{
+   std::string input_line;
+   long count = 0;
+   int sec, lps;
+   time_t start = time(NULL);
+
+   std::cin.sync_with_stdio(false); //disable synchronous IO
+
+	 typedef boost::tokenizer<boost::char_separator<char> > Tokenizer;
+	 boost::char_separator<char> sep(" ");
+
+   while(std::cin)
+   {
+      std::getline(std::cin, input_line);
+			Tokenizer fields(input_line, sep);
+      count++;
+   };
+
+   count--; //subtract for final over-read
+   sec = (int) time(NULL) - start;
+   std::cerr << "C++   : Saw " << count << " lines in " << sec << " seconds." ;
+
+   if (sec > 0)
+   {
+      lps = count / sec;
+      std::cerr << "  Crunch speed: " << lps << std::endl;
+   }
+   else
+      std::cerr << std::endl;
+
+   return 0;
+}

--- a/split9.cpp
+++ b/split9.cpp
@@ -20,9 +20,7 @@ int main()
    std::size_t numWords = 0;
    std::size_t numChars = 0;
 
-   while(std::cin)
-   {
-      std::getline(std::cin, input_line);
+   while(std::getline(std::cin, input_line)) {
       boost::algorithm::split(spline, input_line, boost::algorithm::is_any_of(" "));
       numWords += spline.size();
       for (std::vector<std::string>::const_iterator iter = spline.begin(); iter != spline.end(); ++iter)
@@ -30,7 +28,6 @@ int main()
       count++;
    };
 
-   count--; //subtract for final over-read
    sec = (int) time(NULL) - start;
    std::cerr << "C++   : Saw " << count << " lines (" << numWords << " words/" << numChars << " chars) in " << sec << " seconds." ;
 

--- a/split9.cpp
+++ b/split9.cpp
@@ -1,0 +1,46 @@
+#include <iostream>
+#include <string>
+#include <ctime>
+#include <vector>
+
+#include <boost/algorithm/string/classification.hpp>
+#include <boost/algorithm/string/split.hpp>
+
+
+int main()
+{
+   std::string input_line;
+   long count = 0;
+   int sec, lps;
+   time_t start = time(NULL);
+
+   std::cin.sync_with_stdio(false); //disable synchronous IO
+
+   std::vector<std::string> spline;
+   std::size_t numWords = 0;
+   std::size_t numChars = 0;
+
+   while(std::cin)
+   {
+      std::getline(std::cin, input_line);
+      boost::algorithm::split(spline, input_line, boost::algorithm::is_any_of(" "));
+      numWords += spline.size();
+      for (std::vector<std::string>::const_iterator iter = spline.begin(); iter != spline.end(); ++iter)
+         numChars += iter->size();
+      count++;
+   };
+
+   count--; //subtract for final over-read
+   sec = (int) time(NULL) - start;
+   std::cerr << "C++   : Saw " << count << " lines (" << numWords << " words/" << numChars << " chars) in " << sec << " seconds." ;
+
+   if (sec > 0)
+   {
+      lps = count / sec;
+      std::cerr << "  Crunch speed: " << lps << std::endl;
+   }
+   else
+      std::cerr << std::endl;
+
+   return 0;
+}

--- a/split9.cpp
+++ b/split9.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <iomanip>
 #include <string>
 #include <ctime>
 #include <vector>
@@ -11,8 +12,8 @@ int main()
 {
    std::string input_line;
    long count = 0;
-   int sec, lps;
-   time_t start = time(NULL);
+   timespec start;
+   clock_gettime(CLOCK_MONOTONIC, &start);
 
    std::cin.sync_with_stdio(false); //disable synchronous IO
 
@@ -28,13 +29,15 @@ int main()
       count++;
    };
 
-   sec = (int) time(NULL) - start;
-   std::cerr << "C++   : Saw " << count << " lines (" << numWords << " words/" << numChars << " chars) in " << sec << " seconds." ;
+   timespec end;
+   clock_gettime(CLOCK_MONOTONIC, &end);
+   const double sec = (end.tv_sec - start.tv_sec) + (end.tv_nsec - start.tv_nsec) * 1e-9;
+   std::cerr << "C++   : Saw " << count << " lines (" << numWords << " words/" << numChars << " chars) in " << std::fixed << std::setprecision(1) << sec << " seconds." ;
 
    if (sec > 0)
    {
-      lps = count / sec;
-      std::cerr << "  Crunch speed: " << lps << std::endl;
+      const double lps = count / sec;
+      std::cerr << "  Crunch speed: " << std::fixed << std::setprecision(1) << lps << std::endl;
    }
    else
       std::cerr << std::endl;

--- a/splitc1.cpp
+++ b/splitc1.cpp
@@ -36,8 +36,7 @@ int main() {
     size_t numWords = 0;
     size_t numChars = 0;
 
-    while(cin) {
-        getline(cin, input_line);
+    while(getline(cin, input_line)) {
         spline.clear(); //empty the vector for the next line to parse
 
         splitc1(spline, input_line);  
@@ -48,7 +47,6 @@ int main() {
         count++;
     };
 
-    count--; //subtract for final over-read
     sec = (int) time(NULL) - start;
     cerr << "C++   : Saw " << count << " lines (" << numWords << " words/" << numChars << " chars) in " << sec << " seconds." ;
     if (sec > 0) {

--- a/splitc1.cpp
+++ b/splitc1.cpp
@@ -33,19 +33,24 @@ int main() {
     time_t start = time(NULL);
 
     cin.sync_with_stdio(false); //disable synchronous IO
+    size_t numWords = 0;
+    size_t numChars = 0;
 
     while(cin) {
         getline(cin, input_line);
         spline.clear(); //empty the vector for the next line to parse
 
         splitc1(spline, input_line);  
+        numWords += spline.size();
+        for (vector<string>::const_iterator iter = spline.begin(); iter != spline.end(); ++iter)
+            numChars += iter->size();
 
         count++;
     };
 
     count--; //subtract for final over-read
     sec = (int) time(NULL) - start;
-    cerr << "C++   : Saw " << count << " lines in " << sec << " seconds." ;
+    cerr << "C++   : Saw " << count << " lines (" << numWords << " words/" << numChars << " chars) in " << sec << " seconds." ;
     if (sec > 0) {
         lps = count / sec;
         cerr << "  Crunch speed: " << lps << endl;

--- a/splitc1.cpp
+++ b/splitc1.cpp
@@ -4,6 +4,7 @@
 #include <time.h>
 #include <vector>
 #include <string.h>
+#include <cstdlib>
 
 using namespace std;
 

--- a/splitc1.cpp
+++ b/splitc1.cpp
@@ -1,4 +1,5 @@
 #include <iostream>                                                              
+#include <iomanip>
 #include <string>
 #include <sstream>
 #include <time.h>
@@ -29,8 +30,8 @@ int main() {
     string input_line;
     vector<string> spline;
     long count = 0;
-    int sec, lps;
-    time_t start = time(NULL);
+    timespec start;
+    clock_gettime(CLOCK_MONOTONIC, &start);
 
     cin.sync_with_stdio(false); //disable synchronous IO
     size_t numWords = 0;
@@ -47,11 +48,13 @@ int main() {
         count++;
     };
 
-    sec = (int) time(NULL) - start;
-    cerr << "C++   : Saw " << count << " lines (" << numWords << " words/" << numChars << " chars) in " << sec << " seconds." ;
+    timespec end;
+    clock_gettime(CLOCK_MONOTONIC, &end);
+    const double sec = (end.tv_sec - start.tv_sec) + (end.tv_nsec - start.tv_nsec) * 1e-9;
+    cerr << "C++   : Saw " << count << " lines (" << numWords << " words/" << numChars << " chars) in " << fixed << setprecision(1) << sec << " seconds." ;
     if (sec > 0) {
-        lps = count / sec;
-        cerr << "  Crunch speed: " << lps << endl;
+        const double lps = count / sec;
+        cerr << "  Crunch speed: " << fixed << setprecision(1) << lps << endl;
     } else
         cerr << endl;
     return 0;

--- a/splitc2.cpp
+++ b/splitc2.cpp
@@ -33,6 +33,8 @@ int main() {
     long count = 0;
     int sec, lps;
     time_t start = time(NULL);
+    size_t numWords = 0;
+    size_t numChars = 0;
 
     while((result = fgets(input_line, MAX_LINE, stdin)) != NULL) {
         spline.clear(); //empty the vector for the next line to parse
@@ -42,12 +44,15 @@ int main() {
         }
 
         splitc2(spline, result, " ");
+        numWords += spline.size();
+        for (vector<string>::const_iterator iter = spline.begin(); iter != spline.end(); ++iter)
+            numChars += iter->size();
   
         count++;
     };
 
     sec = (int) time(NULL) - start;
-    cerr << "C++   : Saw " << count << " lines in " << sec << " seconds." ;
+    cerr << "C++   : Saw " << count << " lines (" << numWords << " words/" << numChars << " chars) in " << sec << " seconds." ;
     if (sec > 0) {
         lps = count / sec;
         cerr << "  Crunch speed: " << lps << endl;

--- a/splitc2.cpp
+++ b/splitc2.cpp
@@ -1,4 +1,5 @@
 #include <iostream>                                                              
+#include <iomanip>
 #include <string>
 #include <sstream>
 #include <time.h>
@@ -31,8 +32,8 @@ int main() {
     char input_line[MAX_LINE], *result;
     vector<string> spline;
     long count = 0;
-    int sec, lps;
-    time_t start = time(NULL);
+    timespec start;
+    clock_gettime(CLOCK_MONOTONIC, &start);
     size_t numWords = 0;
     size_t numChars = 0;
 
@@ -51,11 +52,13 @@ int main() {
         count++;
     };
 
-    sec = (int) time(NULL) - start;
-    cerr << "C++   : Saw " << count << " lines (" << numWords << " words/" << numChars << " chars) in " << sec << " seconds." ;
+    timespec end;
+    clock_gettime(CLOCK_MONOTONIC, &end);
+    const double sec = (end.tv_sec - start.tv_sec) + (end.tv_nsec - start.tv_nsec) * 1e-9;
+    cerr << "C++   : Saw " << count << " lines (" << numWords << " words/" << numChars << " chars) in " << fixed << setprecision(1) << sec << " seconds." ;
     if (sec > 0) {
-        lps = count / sec;
-        cerr << "  Crunch speed: " << lps << endl;
+        const double lps = count / sec;
+        cerr << "  Crunch speed: " << fixed << setprecision(1) << lps << endl;
     } else
         cerr << endl;
     return 0;

--- a/splitc2.cpp
+++ b/splitc2.cpp
@@ -5,6 +5,7 @@
 #include <vector>
 #include <cstring>
 #include <cstdio>
+#include <cstdlib>
 
 using namespace std;
 

--- a/splitc3.cpp
+++ b/splitc3.cpp
@@ -1,4 +1,5 @@
 #include <iostream>                                                              
+#include <iomanip>
 #include <string>
 #include <sstream>
 #include <time.h>
@@ -25,8 +26,8 @@ int main() {
     char input_line[MAX_LINE], *result;
     vector<string> spline;
     long count = 0;
-    int sec, lps;
-    time_t start = time(NULL);
+    timespec start;
+    clock_gettime(CLOCK_MONOTONIC, &start);
     size_t numWords = 0;
     size_t numChars = 0;
 
@@ -45,11 +46,13 @@ int main() {
         count++;
     };
 
-    sec = (int) time(NULL) - start;
-    cerr << "C++   : Saw " << count << " lines (" << numWords << " words/" << numChars << " chars) in " << sec << " seconds." ;
+    timespec end;
+    clock_gettime(CLOCK_MONOTONIC, &end);
+    const double sec = (end.tv_sec - start.tv_sec) + (end.tv_nsec - start.tv_nsec) * 1e-9;
+    cerr << "C++   : Saw " << count << " lines (" << numWords << " words/" << numChars << " chars) in " << fixed << setprecision(1) << sec << " seconds." ;
     if (sec > 0) {
-        lps = count / sec;
-        cerr << "  Crunch speed: " << lps << endl;
+        const double lps = count / sec;
+        cerr << "  Crunch speed: " << fixed << setprecision(1) << lps << endl;
     } else
         cerr << endl;
     return 0;

--- a/splitc3.cpp
+++ b/splitc3.cpp
@@ -27,6 +27,8 @@ int main() {
     long count = 0;
     int sec, lps;
     time_t start = time(NULL);
+    size_t numWords = 0;
+    size_t numChars = 0;
 
     while((result = fgets(input_line, MAX_LINE, stdin)) != NULL) {
         spline.clear(); //empty the vector for the next line to parse
@@ -36,12 +38,15 @@ int main() {
         }
 
         splitc3(spline, result, " ");
+        numWords += spline.size();
+        for (vector<string>::const_iterator iter = spline.begin(); iter != spline.end(); ++iter)
+            numChars += iter->size();
   
         count++;
     };
 
     sec = (int) time(NULL) - start;
-    cerr << "C++   : Saw " << count << " lines in " << sec << " seconds." ;
+    cerr << "C++   : Saw " << count << " lines (" << numWords << " words/" << numChars << " chars) in " << sec << " seconds." ;
     if (sec > 0) {
         lps = count / sec;
         cerr << "  Crunch speed: " << lps << endl;


### PR DESCRIPTION
The existing version of the test didn't actually "use" the result, so split7.cpp was basically just counting tokens instead of making them available. This "uses" the data by counting the number of words and characters to verify that it's correct and that the data is actually being generated. This change has some interesting impacts as follows:
1. Python results are slower than C/C++ results (it appears that the individual strings weren't be "created" or something like that)
2. Version based on StrTk (split7) is more in line with the StringRef version (split6) like you'd expect
3. Version based on Boost's tokenizer is notoriously slow when "using" the data and was almost as fast as the StrTk version, but "using" the data reveals that it's the slowest C/C++ version and comparable to the slower Python versions.
