### PR TITLE
Improvements to python and c++ benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /split1
 /split2
+/split3
 /split6
 /split7
 /split8

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-CXXFLAGS = -Wall -O3 -flto -march=native
+CXXFLAGS = -Wall -O3 -flto -march=native -std=c++11
 LDFLAGS = -flto
 
-all: split1 split2 split6 split7 split8 split9 splitc1 splitc2 splitc3 split_subparser
+all: split1 split2 split3 split6 split7 split8 split9 splitc1 splitc2 splitc3 split_subparser
 
 split7: split7.cpp | deps/strtk
 	$(CXX) $(LDFLAGS) -Ideps/strtk/ $(CXXFLAGS) split7.cpp -o split7

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-CXXFLAGS = -Wall -O3
+CXXFLAGS = -Wall -O3 -flto -march=native
+LDFLAGS = -flto
 
 all: split1 split2 split6 split7 split8 split9 splitc1 splitc2 splitc3 split_subparser
 

--- a/readme.txt
+++ b/readme.txt
@@ -27,22 +27,25 @@ https://gist.githubusercontent.com/tobbez/55686ef79bf0b593d90a/raw/789e64318fd91
 
 $ ./run_all.bash 
 === System info
-Linux 3.13.0-57-generic x86_64 GNU/Linux
-Intel(R) Core(TM) i7-2720QM CPU @ 2.20GHz
-g++ (Ubuntu 4.8.4-2ubuntu1~14.04) 4.8.4
-Python 2.7.6
+Ubuntu 15.10
+Linux 4.2.0-19-generic x86_64 GNU/Linux
+Intel(R) Core(TM) i7-4700MQ CPU @ 2.40GHz
+g++ (GCC) 5.2.0
+Python 2.7.10
 === End System info
 
-./split5.py        Python: Saw 20000000 lines (60000000 words/806116396 chars) in 31.2 seconds.  Crunch Speed: 641052.9
-./split.py         Python: Saw 20000000 lines (60000000 words/806116396 chars) in 30.6 seconds.  Crunch Speed: 654202.5
-./split1           C++   : Saw 20000000 lines (60000000 words/806116396 chars) in 15.5 seconds.  Crunch speed: 1293952.3
-./split2           C++   : Saw 20000000 lines (60000000 words/806116396 chars) in 25.7 seconds.  Crunch speed: 776855.9
-./split6           C++   : Saw 20000000 lines (60000000 words/806116396 chars) in 3.1 seconds.  Crunch speed: 6493252.9
-./split7           C++   : Saw 20000000 lines (60000000 words/806116396 chars) in 3.0 seconds.  Crunch speed: 6652254.0
-./split8           C++   : Saw 20000000 lines (60000000 words/806116396 chars) in 48.0 seconds.  Crunch speed: 416639.5
-./split9           C++   : Saw 20000000 lines (60000000 words/806116396 chars) in 27.9 seconds.  Crunch speed: 715600.7
-./splitc1          C++   : Saw 20000000 lines (60000000 words/806116396 chars) in 12.8 seconds.  Crunch speed: 1566162.6
-./splitc2          C++   : Saw 20000000 lines (60000000 words/806116396 chars) in 11.2 seconds.  Crunch speed: 1784909.5
-./splitc3          C++   : Saw 20000000 lines (60000000 words/806116396 chars) in 10.1 seconds.  Crunch speed: 1979358.4
-./split_subparser  C++   : Saw 20000000 lines (60000000 words/806116396 chars) in 2.3 seconds.  Crunch speed: 8742942.4
-
+./split5.py        Python: Saw 20000000 lines (60000000 words/806116396 chars) in 16.0 seconds.  Crunch Speed: 1248867.0
+pypy ./split5.py   Python: Saw 20000000 lines (60000000 words/806116396 chars) in 3.9 seconds.  Crunch Speed: 5188371.6
+./split.py         Python: Saw 20000000 lines (60000000 words/806116396 chars) in 15.2 seconds.  Crunch Speed: 1314968.6
+pypy ./split.py    Python: Saw 20000000 lines (60000000 words/806116396 chars) in 3.4 seconds.  Crunch Speed: 5827597.5
+./split1           C++   : Saw 20000000 lines (60000000 words/806116396 chars) in 5.1 seconds.  Crunch speed: 3916771.3
+./split2           C++   : Saw 20000000 lines (60000000 words/806116396 chars) in 11.6 seconds.  Crunch speed: 1718342.1
+./split3           C++   : Saw 20000000 lines (60000000 words/806116396 chars) in 2.6 seconds.  Crunch speed: 7670585
+./split6           C++   : Saw 20000000 lines (60000000 words/806116396 chars) in 1.6 seconds.  Crunch speed: 12465878.2
+./split7           C++   : Saw 20000000 lines (60000000 words/806116396 chars) in 1.4 seconds.  Crunch speed: 14098300.6
+./split8           C++   : Saw 20000000 lines (60000000 words/806116396 chars) in 12.9 seconds.  Crunch speed: 1547788.4
+./split9           C++   : Saw 20000000 lines (60000000 words/806116396 chars) in 15.0 seconds.  Crunch speed: 1335624.9
+./splitc1          C++   : Saw 20000000 lines (60000000 words/806116396 chars) in 4.8 seconds.  Crunch speed: 4136194.0
+./splitc2          C++   : Saw 20000000 lines (60000000 words/806116396 chars) in 5.1 seconds.  Crunch speed: 3933352.2
+./splitc3          C++   : Saw 20000000 lines (60000000 words/806116396 chars) in 4.3 seconds.  Crunch speed: 4653897.3
+./split_subparser  C++   : Saw 20000000 lines (60000000 words/806116396 chars) in 1.2 seconds.  Crunch speed: 16071186.4

--- a/run_all.bash
+++ b/run_all.bash
@@ -15,8 +15,18 @@ python --version
 echo "=== End System info"
 echo
 
-for i in `find . -maxdepth 1 -executable -iname 'split*.py' | sort ; find . -maxdepth 1 -executable \! -iname '*.py' -iname 'split*' | sort`
-do
+#do python first
+for i in `find . -maxdepth 1 -executable -iname 'split*.py' | sort` ; do
+  printf "%-18s " $i
+  $i < test_data
+
+  printf "pypy %-13s " $i
+  pypy $i < test_data
+
+done
+
+#do c++ timings
+for i in `find . -maxdepth 1 -executable -iname 'split*' | sort |grep -v '\.py$'` ; do
 	printf "%-18s " $i
 	$i < test_data
 done

--- a/split3.cpp
+++ b/split3.cpp
@@ -1,0 +1,102 @@
+//taken from https://stackoverflow.com/questions/9378500/why-is-splitting-a-string-slower-in-c-than-python
+//and modified by Zachary Parchman
+
+
+#include <iostream>                                                              
+#include <iomanip>
+#include <string>
+#include <vector>
+
+#include <boost/date_time/posix_time/conversion.hpp>
+
+using namespace std;
+
+class StringRef
+{
+private:
+    char const*     begin_;
+    int             size_;
+
+public:
+    int size() const { return size_; }
+    char const* begin() const { return begin_; }
+    char const* end() const { return begin_ + size_; }
+
+    StringRef( char const* const begin, int const size )
+        : begin_( begin )
+        , size_( size )
+    {}
+};
+
+vector<StringRef> split3( string const& str, char delimiter = ' ' )
+{
+    vector<StringRef> ret ;
+    ret.reserve(32); //32 is a nice general number. If this was optimized for the benchmark it would be 3
+
+    enum State { inSpace, inToken };
+
+    State state = inSpace;
+    char const*     pTokenBegin = 0;    // Init to satisfy compiler.
+    for( auto it = str.begin(); it != str.end(); ++it )
+    {
+        State const newState = (*it == delimiter? inSpace : inToken);
+        if( newState != state )
+        {
+            switch( newState )
+            {
+            case inSpace:
+                ret.emplace_back(pTokenBegin, &*it - pTokenBegin);
+                break;
+            case inToken:
+                pTokenBegin = &*it;
+            }
+        }
+        state = newState;
+    }
+    if( state == inToken )
+    {
+        ret.emplace_back(pTokenBegin, &*str.end() - pTokenBegin);
+    }
+    return ret;
+}
+
+int main() {
+    string input_line;
+    long count = 0;
+    int lps;
+
+    cin.sync_with_stdio(false); //disable synchronous IO
+
+    timespec start;
+    clock_gettime(CLOCK_MONOTONIC, &start);
+
+
+    int words=0, chars=0;
+    while(cin) {
+        getline(cin, input_line);
+
+        std::vector<StringRef> r = split3( input_line );
+        words += r.size();
+
+        for( const auto & ref : r){
+          chars += ref.size();
+        }
+        count++;
+    };
+
+    count--; //subtract for final over-read
+
+   timespec end;
+   clock_gettime(CLOCK_MONOTONIC, &end);
+   const double sec = (end.tv_sec - start.tv_sec) + (end.tv_nsec - start.tv_nsec) * 1e-9;
+
+    cerr << "C++   : Saw " << count << " lines ("<<words<<" words/" << chars<<" chars) in " << fixed <<setprecision(1)<< sec << " seconds." ;
+    if (sec > 0) {
+        lps = count / sec;
+        cerr << "  Crunch speed: " << setprecision(1)<< lps << endl;
+    } else
+        cerr << endl;
+    return 0;
+}
+
+//compiled with: g++ -Wall -O3 -o split3 split_3.cpp -std=c++11 -flto -march=native

--- a/split8.cpp
+++ b/split8.cpp
@@ -23,9 +23,10 @@ int main()
 
    while(std::getline(std::cin, input_line)) {
       Tokenizer fields(input_line, sep);
-      numWords += std::distance(fields.begin(), fields.end());
-      for (Tokenizer::const_iterator iter = fields.begin(); iter != fields.end(); ++iter)
-         numChars += iter->size();
+      for( Tokenizer::const_iterator iter = fields.begin(); iter != fields.end(); ++iter){
+        numChars += iter->size();
+        ++numWords;
+      }
       count++;
    };
 


### PR DESCRIPTION
I've added pypy support, improved split8.cpp and added split3.cpp. The addition of pypy makes this benchmark much more interesting as shown by the numbers in the updated readme.
